### PR TITLE
CCM-6603 Add CI Overload permissions

### DIFF
--- a/infrastructure/terraform/components/acct/iam_policy_github_deploy_overload.tf
+++ b/infrastructure/terraform/components/acct/iam_policy_github_deploy_overload.tf
@@ -1,0 +1,25 @@
+resource "aws_iam_policy" "github_deploy_overload" {
+  name        = "${local.csi}-github-deploy-overload"
+  description = "Overloads the github permission to perform build actions for services in this account"
+  policy      = data.aws_iam_policy_document.github_deploy.json
+}
+
+resource "aws_iam_role_policy_attachment" "github_deploy_overload" {
+  role       = local.bootstrap.iam_github_deploy_role["name"]
+  policy_arn = aws_iam_policy.github_deploy_overload.arn
+}
+
+#tfsec:ignore:aws-iam-no-policy-wildcards Policy voilation expected for CI user role
+data "aws_iam_policy_document" "github_deploy" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "athena:*",
+      "firehose:*",
+      "glue:*",
+      "kinesis:*",
+    ]
+    resources = ["*"]
+  }
+}

--- a/infrastructure/terraform/components/acct/locals_remote_state.tf
+++ b/infrastructure/terraform/components/acct/locals_remote_state.tf
@@ -1,0 +1,21 @@
+locals {
+  bootstrap = data.terraform_remote_state.bootstrap.outputs
+}
+
+data "terraform_remote_state" "bootstrap" {
+  backend = "s3"
+
+  config = {
+    bucket = local.terraform_state_bucket
+
+    key = format(
+      "%s/%s/%s/%s/bootstrap.tfstate",
+      var.project,
+      var.aws_account_id,
+      "eu-west-2",
+      "bootstrap"
+    )
+
+    region = "eu-west-2"
+  }
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
Adds an overload from the bootstrapped CI role used with ones specific to the domain resources

**Related PRs:**
internal - https://github.com/NHSDigital/nhs-notify-internal/pull/128
iam-webauth - https://github.com/NHSDigital/nhs-notify-iam-webauth/pull/57
web-templates - https://github.com/NHSDigital/nhs-notify-web-template-management/pull/98
web-gateway - https://github.com/NHSDigital/nhs-notify-web-gateway/pull/18
reporting - https://github.com/NHSDigital/nhs-notify-reporting/pull/56
dns repo does not require change (defaults in CI role are sufficient)

Rollout - 
The rollout of this PR will require all accounts running the code from the linked Repo's to have their bootstrap applied, then the accounts component applied to ensure the CI role is working again.

Validation of all known CSIs will be completed to make sure the CI roles are able to build the services still

## Context

<!-- Why is this change required? What problem does it solve? -->
At present the role used by the Github CI has a consistent role and set of permissions for all the AWS accounts, this proabably is going to break the principal of least privilege as the service grows. Until recently this wasn't much of a problem, but Amplify's scope keeps extending and we should now solve the problem.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
