### PR TITLE
date table automatically to end of current year

### DIFF
--- a/infrastructure/terraform/components/reporting/scripts/sql/views/dates.sql
+++ b/infrastructure/terraform/components/reporting/scripts/sql/views/dates.sql
@@ -5,6 +5,6 @@ SELECT
   month(t.date) month,
   day(t.date) day
 FROM (
-  SELECT sequence(DATE('2023-06-01'), DATE(CURRENT_DATE), INTERVAL '1' DAY) dates
+  SELECT sequence(DATE('2023-01-01'), DATE(concat(cast(YEAR(current_date) as varchar), '-12-31')), INTERVAL '1' DAY) dates
 ),
 UNNEST(dates) t (date)


### PR DESCRIPTION
Automatic end date based on 31 December of current year