### PR TITLE
CCM-6919 Reporting S3 Backups

### DIFF
--- a/infrastructure/terraform/components/reporting/backup_plan_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/backup_plan_s3_backup.tf
@@ -1,0 +1,25 @@
+resource "aws_backup_plan" "s3_backup" {
+  count = var.enable_s3_backup ? 1 : 0
+
+  name = "${local.csi}-backup-plan"
+
+  rule {
+    rule_name                = "ContinuousBackupRule"
+    target_vault_name        = aws_backup_vault.s3_backup[0].name
+    enable_continuous_backup = true
+
+    lifecycle {
+      delete_after = var.continuous_s3backup_retention_days
+    }
+  }
+
+  rule {
+    rule_name         = "PeriodicBackupRule"
+    target_vault_name = aws_backup_vault.s3_backup[0].name
+    schedule          = var.periodic_s3backup_schedule
+
+    lifecycle {
+      delete_after = var.periodic_s3backup_retention_days
+    }
+  }
+}

--- a/infrastructure/terraform/components/reporting/backup_plan_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/backup_plan_s3_backup.tf
@@ -14,9 +14,10 @@ resource "aws_backup_plan" "s3_backup" {
   }
 
   rule {
-    rule_name         = "PeriodicBackupRule"
-    target_vault_name = aws_backup_vault.s3_backup[0].name
-    schedule          = var.periodic_s3backup_schedule
+    rule_name                = "PeriodicBackupRule"
+    target_vault_name        = aws_backup_vault.s3_backup[0].name
+    schedule                 = var.periodic_s3backup_schedule
+    enable_continuous_backup = false
 
     lifecycle {
       delete_after = var.periodic_s3backup_retention_days

--- a/infrastructure/terraform/components/reporting/backup_selection_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/backup_selection_s3_backup.tf
@@ -1,0 +1,12 @@
+resource "aws_backup_selection" "s3_backup" {
+  count = var.enable_s3_backup ? 1 : 0
+
+  iam_role_arn = aws_iam_role.s3_backup[0].arn
+  name         = "${local.csi}-s3"
+  plan_id      = aws_backup_plan.s3_backup[0].id
+
+  resources = [
+    aws_s3_bucket.data.arn,
+    aws_s3_bucket.results.arn
+  ]
+}

--- a/infrastructure/terraform/components/reporting/backup_selection_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/backup_selection_s3_backup.tf
@@ -7,6 +7,5 @@ resource "aws_backup_selection" "s3_backup" {
 
   resources = [
     aws_s3_bucket.data.arn,
-    aws_s3_bucket.results.arn
   ]
 }

--- a/infrastructure/terraform/components/reporting/backup_vault_lock_configuration_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/backup_vault_lock_configuration_s3_backup.tf
@@ -1,0 +1,5 @@
+resource "aws_backup_vault_lock_configuration" "s3_backup" {
+  count = var.enable_s3_backup && var.enable_vault_lock_configuration ? 1 : 0
+
+  backup_vault_name   = aws_backup_vault.s3_backup[0].name
+}

--- a/infrastructure/terraform/components/reporting/backup_vault_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/backup_vault_s3_backup.tf
@@ -1,0 +1,6 @@
+resource "aws_backup_vault" "s3_backup" {
+  count = var.enable_s3_backup ? 1 : 0
+
+  name        = "${local.csi}-vault"
+  kms_key_arn = aws_kms_key.backup[0].arn
+}

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_s3_backup_failures.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_s3_backup_failures.tf
@@ -1,0 +1,16 @@
+resource "aws_cloudwatch_metric_alarm" "s3_backup_failures" {
+  alarm_name                = "${local.csi}-s3-backup-failures"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = 1
+  metric_name               = "NumberOfBackupJobsFailed"
+  namespace                 = "AWS/Backup"
+  period                    = 60
+  statistic                 = "Sum"
+  threshold                 = 1
+  alarm_description         = "This metric monitors AWS Backup Failures"
+  insufficient_data_actions = []
+
+  dimensions = {
+    BackupVaultName = aws_backup_vault.s3_backup.name
+  }
+}

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_s3_backup_failures.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_s3_backup_failures.tf
@@ -1,4 +1,6 @@
 resource "aws_cloudwatch_metric_alarm" "s3_backup_failures" {
+  count = var.enable_s3_backup ? 1 : 0
+
   alarm_name                = "${local.csi}-s3-backup-failures"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   evaluation_periods        = 1
@@ -11,6 +13,6 @@ resource "aws_cloudwatch_metric_alarm" "s3_backup_failures" {
   insufficient_data_actions = []
 
   dimensions = {
-    BackupVaultName = aws_backup_vault.s3_backup.name
+    BackupVaultName = aws_backup_vault.s3_backup[0].name
   }
 }

--- a/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup.tf
@@ -29,6 +29,7 @@ data "aws_iam_policy_document" "s3_backup" {
       "events:PutRule",
       "events:ListTargetsByRule",
       "events:PutTargets",
+      "events:RemoveTargets",
       "cloudwatch:GetMetricData"
     ]
     resources = ["*"]

--- a/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup.tf
@@ -5,8 +5,12 @@ data "aws_iam_policy_document" "s3_backup" {
     actions = [
       "s3:GetObject",
       "s3:ListBucket",
+      "s3:ListBucketVersions",
       "s3:GetBucketVersioning",
-      "s3:GetBucketTagging"
+      "s3:GetBucketTagging",
+      "s3:GetBucketLocation",
+      "s3:GetBucketNotification",
+      "s3:PutBucketNotification"
     ]
     resources = [
       aws_s3_bucket.data.arn,
@@ -20,7 +24,12 @@ data "aws_iam_policy_document" "s3_backup" {
     actions = [
       "backup:StartBackupJob",
       "backup:ListRecoveryPointsByBackupVault",
-      "backup:StartRestoreJob"
+      "backup:StartRestoreJob",
+      "events:ListRules",
+      "events:PutRule",
+      "events:ListTargetsByRule",
+      "events:PutTargets",
+      "cloudwatch:GetMetricData"
     ]
     resources = ["*"]
   }

--- a/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup.tf
@@ -1,0 +1,26 @@
+data "aws_iam_policy_document" "s3_backup" {
+  count = var.enable_s3_backup ? 1 : 0
+
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:GetBucketVersioning"
+    ]
+    resources = [
+      aws_s3_bucket.data.arn,
+      "${aws_s3_bucket.data.arn}/*",
+      aws_s3_bucket.results.arn,
+      "${aws_s3_bucket.results.arn}/*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "backup:StartBackupJob",
+      "backup:ListRecoveryPointsByBackupVault",
+      "backup:StartRestoreJob"
+    ]
+    resources = ["*"]
+  }
+}

--- a/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup.tf
@@ -15,8 +15,6 @@ data "aws_iam_policy_document" "s3_backup" {
     resources = [
       aws_s3_bucket.data.arn,
       "${aws_s3_bucket.data.arn}/*",
-      aws_s3_bucket.results.arn,
-      "${aws_s3_bucket.results.arn}/*"
     ]
   }
 

--- a/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup.tf
@@ -5,7 +5,8 @@ data "aws_iam_policy_document" "s3_backup" {
     actions = [
       "s3:GetObject",
       "s3:ListBucket",
-      "s3:GetBucketVersioning"
+      "s3:GetBucketVersioning",
+      "s3:GetBucketTagging"
     ]
     resources = [
       aws_s3_bucket.data.arn,

--- a/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup.tf
@@ -22,16 +22,44 @@ data "aws_iam_policy_document" "s3_backup" {
 
   statement {
     actions = [
-      "backup:StartBackupJob",
-      "backup:ListRecoveryPointsByBackupVault",
-      "backup:StartRestoreJob",
-      "events:ListRules",
-      "events:PutRule",
       "events:DeleteRule",
+      "events:DescribeRule",
+      "events:DisableRule",
+      "events:EnableRule",
+      "events:ListRules",
       "events:ListTargetsByRule",
+      "events:PutRule",
       "events:PutTargets",
-      "events:RemoveTargets",
-      "cloudwatch:GetMetricData"
+      "events:RemoveTargets"
+    ]
+    resources = [
+      "arn:aws:events:${var.region}:${local.this_account}:rule/AwsBackupManagedRule-*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "backup:ListRecoveryPointsByBackupVault",
+      "backup:StartBackupJob",
+    ]
+    resources = [
+      aws_backup_vault.s3_backup[0].arn
+    ]
+  }
+
+  statement {
+    actions = [
+      "backup:StartRestoreJob"
+    ]
+    resources = [
+      "arn:aws:backup:${var.region}:${local.this_account}:recovery-point:${var.project}-${local.this_account}-${var.region}-${var.environment}-*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "cloudwatch:GetMetricData", # List action, cannot be scoped
+      "events:ListRules"          # List action, cannot be scoped
     ]
     resources = ["*"]
   }

--- a/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup.tf
@@ -27,6 +27,7 @@ data "aws_iam_policy_document" "s3_backup" {
       "backup:StartRestoreJob",
       "events:ListRules",
       "events:PutRule",
+      "events:DeleteRule",
       "events:ListTargetsByRule",
       "events:PutTargets",
       "events:RemoveTargets",

--- a/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup_assume_role.tf
+++ b/infrastructure/terraform/components/reporting/data_iam_policy_document_s3_backup_assume_role.tf
@@ -1,0 +1,11 @@
+data "aws_iam_policy_document" "s3_backup_assume_role" {
+  count = var.enable_s3_backup ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["backup.amazonaws.com"]
+    }
+  }
+}

--- a/infrastructure/terraform/components/reporting/iam_policy_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/iam_policy_s3_backup.tf
@@ -1,0 +1,7 @@
+resource "aws_iam_policy" "s3_backup" {
+  count = var.enable_s3_backup ? 1 : 0
+
+  name        = "${local.csi}-AWSBackupS3AccessPolicy"
+  description = "IAM policy for AWS Backup to access Reporting S3 buckets"
+  policy      = data.aws_iam_policy_document.s3_backup[0].json
+}

--- a/infrastructure/terraform/components/reporting/iam_role_policy_attachment_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/iam_role_policy_attachment_s3_backup.tf
@@ -1,0 +1,6 @@
+resource "aws_iam_role_policy_attachment" "s3_backup" {
+  count = var.enable_s3_backup ? 1 : 0
+
+  role       = aws_iam_role.s3_backup[0].name
+  policy_arn = aws_iam_policy.s3_backup[0].arn
+}

--- a/infrastructure/terraform/components/reporting/iam_role_policy_attachment_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/iam_role_policy_attachment_s3_backup.tf
@@ -4,3 +4,17 @@ resource "aws_iam_role_policy_attachment" "s3_backup" {
   role       = aws_iam_role.s3_backup[0].name
   policy_arn = aws_iam_policy.s3_backup[0].arn
 }
+
+resource "aws_iam_role_policy_attachment" "managed_backup" {
+  count = var.enable_s3_backup ? 1 : 0
+
+  role       = aws_iam_role.s3_backup[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup"
+}
+
+resource "aws_iam_role_policy_attachment" "managed_restore" {
+  count = var.enable_s3_backup ? 1 : 0
+
+  role       = aws_iam_role.s3_backup[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Restore"
+}

--- a/infrastructure/terraform/components/reporting/iam_role_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/iam_role_s3_backup.tf
@@ -1,0 +1,7 @@
+resource "aws_iam_role" "s3_backup" {
+  count = var.enable_s3_backup ? 1 : 0
+
+  name               = "${local.csi}-AWSBackupServiceRole"
+  description        = "AWS S3 Backup Role"
+  assume_role_policy = data.aws_iam_policy_document.s3_backup_assume_role[0].json
+}

--- a/infrastructure/terraform/components/reporting/iam_role_s3_backup.tf
+++ b/infrastructure/terraform/components/reporting/iam_role_s3_backup.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role" "s3_backup" {
   count = var.enable_s3_backup ? 1 : 0
 
-  name               = "${local.csi}-AWSBackupServiceRole"
-  description        = "AWS S3 Backup Role"
-  assume_role_policy = data.aws_iam_policy_document.s3_backup_assume_role[0].json
+  name                = "${local.csi}-AWSBackupServiceRole"
+  description         = "AWS S3 Backup Role"
+  assume_role_policy  = data.aws_iam_policy_document.s3_backup_assume_role[0].json
 }

--- a/infrastructure/terraform/components/reporting/kms_key_backup.tf
+++ b/infrastructure/terraform/components/reporting/kms_key_backup.tf
@@ -1,0 +1,108 @@
+resource "aws_kms_key" "backup" {
+  count = var.enable_s3_backup ? 1 : 0
+
+
+  description             = "CMK for encrypting backup vault"
+  deletion_window_in_days = local.parameter_bundle.default_kms_deletion_window_in_days
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.backup[0].json
+}
+
+resource "aws_kms_alias" "backup" {
+  count = var.enable_s3_backup ? 1 : 0
+
+  name          = "alias/${local.csi}-backup"
+  target_key_id = aws_kms_key.backup[0].key_id
+}
+
+
+data "aws_iam_policy_document" "backup" {
+  count = var.enable_s3_backup ? 1 : 0
+
+  statement {
+    sid    = "AllowLocalIAMAdministration"
+    effect = "Allow"
+
+    actions = [
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion",
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:GenerateDataKey",
+      "kms:TagResource"
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        local.parameter_bundle.iam_resource_arns.any_authorised_user_in_this_account,
+
+      ]
+    }
+  }
+
+  statement {
+    sid    = "AllowUsageAccess"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*",
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        local.parameter_bundle.iam_resource_arns.any_authorised_user_in_this_account,
+        "arn:aws:iam::${local.this_account}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
+
+      ]
+    }
+  }
+  statement {
+    sid    = "AllowAutoscalingToUse"
+    effect = "Allow"
+
+    actions = [
+      "kms:CreateGrant",
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${local.this_account}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+      ]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values   = ["true"]
+    }
+  }
+}

--- a/infrastructure/terraform/components/reporting/kms_key_backup.tf
+++ b/infrastructure/terraform/components/reporting/kms_key_backup.tf
@@ -74,35 +74,8 @@ data "aws_iam_policy_document" "backup" {
     principals {
       type = "AWS"
       identifiers = [
-        local.parameter_bundle.iam_resource_arns.any_authorised_user_in_this_account,
-        "arn:aws:iam::${local.this_account}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
-
+        local.parameter_bundle.iam_resource_arns.any_authorised_user_in_this_account
       ]
-    }
-  }
-  statement {
-    sid    = "AllowAutoscalingToUse"
-    effect = "Allow"
-
-    actions = [
-      "kms:CreateGrant",
-    ]
-
-    resources = [
-      "*",
-    ]
-
-    principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${local.this_account}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
-      ]
-    }
-
-    condition {
-      test     = "Bool"
-      variable = "kms:GrantIsForAWSResource"
-      values   = ["true"]
     }
   }
 }

--- a/infrastructure/terraform/components/reporting/variables.tf
+++ b/infrastructure/terraform/components/reporting/variables.tf
@@ -185,7 +185,7 @@ variable "continuous_s3backup_retention_days" {
 variable "periodic_s3backup_retention_days" {
   type        = number
   description = "number of days to retain weekly s3 backups"
-  default     = 365
+  default     = 90
 }
 
 variable "periodic_s3backup_schedule" {

--- a/infrastructure/terraform/components/reporting/variables.tf
+++ b/infrastructure/terraform/components/reporting/variables.tf
@@ -178,7 +178,7 @@ variable "enable_s3_backup" {
 
 variable "continuous_s3backup_retention_days" {
   type        = number
-  description = "number of days to retain continous s3 restore points for PITR - Maximum is 35 days"
+  description = "number of days to retain continous s3 restore points for PITR - Maximum 35 days"
   default     = 35
 }
 

--- a/infrastructure/terraform/components/reporting/variables.tf
+++ b/infrastructure/terraform/components/reporting/variables.tf
@@ -189,9 +189,9 @@ variable "periodic_s3backup_retention_days" {
 }
 
 variable "periodic_s3backup_schedule" {
-  type = string
+  type        = string
   description = "Crontab formatted schedule for Periodic S3 Backups"
-  default = "cron(0 5 ? * 7 *)" # Runs every Saturday at 5 AM UTC
+  default     = "cron(0 5 ? * 7 *)" # Runs every Saturday at 5 AM UTC
 }
 
 variable "enable_vault_lock_configuration" {

--- a/infrastructure/terraform/components/reporting/variables.tf
+++ b/infrastructure/terraform/components/reporting/variables.tf
@@ -179,13 +179,13 @@ variable "enable_s3_backup" {
 variable "continuous_s3backup_retention_days" {
   type        = number
   description = "number of days to retain continous s3 backups for PITR"
-  default     = "90"
+  default     = 90
 }
 
 variable "periodic_s3backup_retention_days" {
   type        = number
   description = "number of days to retain weekly s3 backups"
-  default     = "365"
+  default     = 365
 }
 
 variable "periodic_s3backup_schedule" {

--- a/infrastructure/terraform/components/reporting/variables.tf
+++ b/infrastructure/terraform/components/reporting/variables.tf
@@ -172,7 +172,7 @@ variable "batch_client_ids" {
 
 variable "enable_s3_backup" {
   type        = bool
-  description = "Enable AWS S3 Backup of data and results buckets"
+  description = "Enable AWS S3 Backup of the data bucket"
   default     = true
 }
 

--- a/infrastructure/terraform/components/reporting/variables.tf
+++ b/infrastructure/terraform/components/reporting/variables.tf
@@ -169,3 +169,33 @@ variable "batch_client_ids" {
   type = list(string)
   default = ["NULL"]
 }
+
+variable "enable_s3_backup" {
+  type        = bool
+  description = "Enable AWS S3 Backup of data and results buckets"
+  default     = true
+}
+
+variable "continuous_s3backup_retention_days" {
+  type        = number
+  description = "number of days to retain continous s3 backups for PITR"
+  default     = "90"
+}
+
+variable "periodic_s3backup_retention_days" {
+  type        = number
+  description = "number of days to retain weekly s3 backups"
+  default     = "365"
+}
+
+variable "periodic_s3backup_schedule" {
+  type = string
+  description = "Crontab formatted schedule for Periodic S3 Backups"
+  default = "cron(0 5 ? * 7 *)" # Runs every Saturday at 5 AM UTC
+}
+
+variable "enable_vault_lock_configuration" {
+  type        = bool
+  description = "Enable vault lock, preventing the deletion of a vault that contains 1 or more Recovery Points"
+  default     = false
+}

--- a/infrastructure/terraform/components/reporting/variables.tf
+++ b/infrastructure/terraform/components/reporting/variables.tf
@@ -179,7 +179,7 @@ variable "enable_s3_backup" {
 variable "continuous_s3backup_retention_days" {
   type        = number
   description = "number of days to retain continous s3 backups for PITR"
-  default     = 90
+  default     = 35
 }
 
 variable "periodic_s3backup_retention_days" {

--- a/infrastructure/terraform/components/reporting/variables.tf
+++ b/infrastructure/terraform/components/reporting/variables.tf
@@ -178,7 +178,7 @@ variable "enable_s3_backup" {
 
 variable "continuous_s3backup_retention_days" {
   type        = number
-  description = "number of days to retain continous s3 backups for PITR"
+  description = "number of days to retain continous s3 restore points for PITR - Maximum is 35 days"
   default     = 35
 }
 

--- a/infrastructure/terraform/etc/env_eu-west-2_prod.tfvars
+++ b/infrastructure/terraform/etc/env_eu-west-2_prod.tfvars
@@ -31,3 +31,5 @@ batch_client_ids = [
   "c10ab104-86ae-48dc-b243-4906760952d3",
   "688040bc-92ea-4037-89f4-d105c9ae59a4"
 ]
+
+enable_vault_lock_configuration = true

--- a/infrastructure/terraform/etc/env_eu-west-2_ref.tfvars
+++ b/infrastructure/terraform/etc/env_eu-west-2_ref.tfvars
@@ -31,3 +31,5 @@ batch_client_ids = [
   "perf-test-client-1",
   "perf-test-client-2"
 ]
+
+enable_s3_backup = false

--- a/infrastructure/terraform/etc/env_eu-west-2_uat.tfvars
+++ b/infrastructure/terraform/etc/env_eu-west-2_uat.tfvars
@@ -26,3 +26,5 @@ min_size         = 1
 max_size         = 1
 enable_spot      = false
 spot_max_price   = "0.3"
+
+enable_s3_backup = false


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds the facility to backup the data and results buckets via AWS Backup's continuous backups for 35 days (the maximum extent possible for continuous) and weekly periodic backups for 90 days. These numbers are subject to change so please add any comments as necessary.

## Context

Allows for the restoration to a point-in-time of the Athena data contained in each of the data and results buckets. 

Defaults to on. All settings can be tailored via variables in tfvars files. Vault lock available but not initially turned on by default.

Also adds a cloudwatch alarm to catch failed backups.

It'd be nice to get at least this PR merged in order to get it in main, such that I can test the restore process and produce the KOP. It's not entirely unlikely that would require a follow up PR to massage perms etc but without the backups in main it's difficult to test!

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
