### PR TITLE
CCM-7741: add sending group columns to report

### DIFF
--- a/infrastructure/terraform/components/reporting/null_resource_request_item_status_table.tf
+++ b/infrastructure/terraform/components/reporting/null_resource_request_item_status_table.tf
@@ -60,3 +60,35 @@ resource "null_resource" "request_item_status_sendinggroupidversion_column" {
 
   depends_on = [null_resource.request_item_status_requestitemrefid_column]
 }
+
+resource "null_resource" "request_item_status_sendinggroupname_column" {
+  triggers = {
+    always_run = timestamp()
+  }
+  provisioner "local-exec" {
+    command = <<EOT
+      ${path.module}/scripts/add_column.sh \
+        ${aws_athena_workgroup.setup.name} \
+        ${aws_glue_catalog_database.reporting.name} \
+        request_item_status sendinggroupname string
+    EOT
+  }
+
+  depends_on = [null_resource.request_item_status_sendinggroupidversion_column]
+}
+
+resource "null_resource" "request_item_status_sendinggroupcreateddate_column" {
+  triggers = {
+    always_run = timestamp()
+  }
+  provisioner "local-exec" {
+    command = <<EOT
+      ${path.module}/scripts/add_column.sh \
+        ${aws_athena_workgroup.setup.name} \
+        ${aws_glue_catalog_database.reporting.name} \
+        request_item_status sendinggroupcreateddate string
+    EOT
+  }
+
+  depends_on = [null_resource.request_item_status_sendinggroupname_column]
+}

--- a/infrastructure/terraform/components/reporting/scripts/sql/ingestion/request_item_status.sql
+++ b/infrastructure/terraform/components/reporting/scripts/sql/ingestion/request_item_status.sql
@@ -14,6 +14,8 @@ USING (
         campaignid,
         sendinggroupid,
         sendinggroupidversion,
+        sendinggroupname,
+        sendinggroupcreateddate,
         requestitemrefid,
         requestitemid,
         requestrefid,
@@ -26,9 +28,7 @@ USING (
         status,
         failedreason,
         patientodscode,
-        CAST("$classification".timestamp AS BIGINT) AS timestamp,
-        sendinggroupname,
-        sendinggroupcreateddate
+        CAST("$classification".timestamp AS BIGINT) AS timestamp
       FROM ${source_table}
       WHERE (sk LIKE 'REQUEST_ITEM#%') AND
       (
@@ -46,6 +46,8 @@ WHEN MATCHED AND (source.timestamp > target.timestamp) THEN UPDATE SET
   campaignid = source.campaignid,
   sendinggroupid = source.sendinggroupid,
   sendinggroupidversion = source.sendinggroupidversion,
+  sendinggroupname = source.sendinggroupname,
+  sendinggroupcreateddate = source.sendinggroupcreateddate,
   requestitemrefid = source.requestitemrefid,
   requestrefid = source.requestrefid,
   requestid = source.requestid,
@@ -57,14 +59,14 @@ WHEN MATCHED AND (source.timestamp > target.timestamp) THEN UPDATE SET
   status = source.status,
   failedreason = source.failedreason,
   patientodscode = source.patientodscode,
-  timestamp = source.timestamp,
-  sendinggroupname = source.sendinggroupname,
-  sendinggroupcreateddate = source.sendinggroupcreateddate
+  timestamp = source.timestamp
 WHEN NOT MATCHED THEN INSERT (
   clientid,
   campaignid,
   sendinggroupid,
   sendinggroupidversion,
+  sendinggroupname,
+  sendinggroupcreateddate,
   requestitemrefid,
   requestitemid,
   requestrefid,
@@ -77,15 +79,15 @@ WHEN NOT MATCHED THEN INSERT (
   status,
   failedreason,
   patientodscode,
-  timestamp,
-  sendinggroupname,
-  sendinggroupcreateddate
+  timestamp
 )
 VALUES (
   source.clientid,
   source.campaignid,
   source.sendinggroupid,
   source.sendinggroupidversion,
+  source.sendinggroupname,
+  source.sendinggroupcreateddate,
   source.requestitemrefid,
   source.requestitemid,
   source.requestrefid,
@@ -98,7 +100,5 @@ VALUES (
   source.status,
   source.failedreason,
   source.patientodscode,
-  source.timestamp,
-  source.sendinggroupname,
-  source.sendinggroupcreateddate
+  source.timestamp
 )

--- a/infrastructure/terraform/components/reporting/scripts/sql/ingestion/request_item_status.sql
+++ b/infrastructure/terraform/components/reporting/scripts/sql/ingestion/request_item_status.sql
@@ -26,7 +26,9 @@ USING (
         status,
         failedreason,
         patientodscode,
-        CAST("$classification".timestamp AS BIGINT) AS timestamp
+        CAST("$classification".timestamp AS BIGINT) AS timestamp,
+        sendinggroupname,
+        sendinggroupcreateddate
       FROM ${source_table}
       WHERE (sk LIKE 'REQUEST_ITEM#%') AND
       (
@@ -55,7 +57,9 @@ WHEN MATCHED AND (source.timestamp > target.timestamp) THEN UPDATE SET
   status = source.status,
   failedreason = source.failedreason,
   patientodscode = source.patientodscode,
-  timestamp = source.timestamp
+  timestamp = source.timestamp,
+  sendinggroupname = source.sendinggroupname,
+  sendinggroupcreateddate = source.sendinggroupcreateddate,
 WHEN NOT MATCHED THEN INSERT (
   clientid,
   campaignid,
@@ -73,7 +77,9 @@ WHEN NOT MATCHED THEN INSERT (
   status,
   failedreason,
   patientodscode,
-  timestamp
+  timestamp,
+  sendinggroupname,
+  sendinggroupcreateddate
 )
 VALUES (
   source.clientid,
@@ -92,5 +98,7 @@ VALUES (
   source.status,
   source.failedreason,
   source.patientodscode,
-  source.timestamp
+  source.timestamp,
+  source.sendinggroupname,
+  source.sendinggroupcreateddate
 )

--- a/infrastructure/terraform/components/reporting/scripts/sql/ingestion/request_item_status.sql
+++ b/infrastructure/terraform/components/reporting/scripts/sql/ingestion/request_item_status.sql
@@ -59,7 +59,7 @@ WHEN MATCHED AND (source.timestamp > target.timestamp) THEN UPDATE SET
   patientodscode = source.patientodscode,
   timestamp = source.timestamp,
   sendinggroupname = source.sendinggroupname,
-  sendinggroupcreateddate = source.sendinggroupcreateddate,
+  sendinggroupcreateddate = source.sendinggroupcreateddate
 WHEN NOT MATCHED THEN INSERT (
   clientid,
   campaignid,

--- a/infrastructure/terraform/components/reporting/scripts/sql/reports/completed_comms_report.sql
+++ b/infrastructure/terraform/components/reporting/scripts/sql/reports/completed_comms_report.sql
@@ -7,6 +7,8 @@ SELECT
     ri.failedReason as requestitemfailedreason,
     ri.sendingGroupId as sendinggroupid,
     ri.sendingGroupIdVersion as sendinggroupidversion,
+    ri.sendingGroupName as sendinggroupname,
+    ri.sendingGroupCreatedDate as sendinggroupcreateddate,
     ri.status AS requestitemstatus,
     rip.requestitemplanid AS requestitemplanid,
     DATE(rip.completedtime) AS requestitemplancompleteddate,

--- a/infrastructure/terraform/components/reporting/scripts/sql/tables/request_item_status.sql
+++ b/infrastructure/terraform/components/reporting/scripts/sql/tables/request_item_status.sql
@@ -3,6 +3,8 @@ CREATE TABLE IF NOT EXISTS ${table_name} (
     campaignid string,
     sendinggroupid string,
     sendinggroupidversion string,
+    sendinggroupname string,
+    sendinggroupcreateddate string,
     requestitemrefid string,
     requestitemid string,
     requestrefid string,

--- a/infrastructure/terraform/components/reporting/templates/completed_comms_report.json.tmpl
+++ b/infrastructure/terraform/components/reporting/templates/completed_comms_report.json.tmpl
@@ -61,7 +61,7 @@
     },
     "Get Completed Date From Args": {
       "Type": "Pass",
-      "Next": "For Each Client Id",
+      "Next": "Get Report Query",
       "Parameters": {
         "completedDate.$": "$.completedDate"
       },
@@ -101,28 +101,29 @@
         "completedDate.$": "$.ResultSet.Rows[1].Data[0].VarCharValue"
       }
     },
+    "Get Report Query": {
+      "Type": "Task",
+      "Parameters": {
+        "NamedQueryId": "${report_query_id}"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:athena:getNamedQuery",
+      "Next": "For Each Client Id",
+      "ResultPath": "$.ReportQuery"
+    },
     "For Each Client Id": {
       "Type": "Map",
       "ItemsPath": "$.useClientIds.clientIds",
       "ItemSelector": {
         "clientId.$": "$$.Map.Item.Value",
-        "completedDate.$": "$.useCompletedDate.completedDate"
+        "completedDate.$": "$.useCompletedDate.completedDate",
+        "ReportQuery.$": "$.ReportQuery"
       },
       "ItemProcessor": {
         "ProcessorConfig": {
           "Mode": "INLINE"
         },
-        "StartAt": "Get Report Query",
+        "StartAt": "Execute Report Query",
         "States": {
-          "Get Report Query": {
-            "Type": "Task",
-            "Parameters": {
-              "NamedQueryId": "${report_query_id}"
-            },
-            "Resource": "arn:aws:states:::aws-sdk:athena:getNamedQuery",
-            "Next": "Execute Report Query",
-            "ResultPath": "$.ReportQuery"
-          },
           "Execute Report Query": {
             "Resource": "arn:aws:states:::athena:startQueryExecution.sync",
             "Parameters": {

--- a/infrastructure/terraform/components/reporting/templates/completed_comms_report.json.tmpl
+++ b/infrastructure/terraform/components/reporting/templates/completed_comms_report.json.tmpl
@@ -95,7 +95,7 @@
       "Parameters": {
         "QueryExecutionId.$": "$.DateQueryExecution.QueryExecution.QueryExecutionId"
       },
-      "Next": "For Each Client Id",
+      "Next": "Get Report Query",
       "ResultPath": "$.useCompletedDate",
       "ResultSelector": {
         "completedDate.$": "$.ResultSet.Rows[1].Data[0].VarCharValue"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds `sendinggroupname` and `sendinggroupcreateddate` columns into the `request_item_status` table and into the completed comms report.

Also updates the completed comms report step function so that it only pulls the report saved query from Athena once, rather than once per client, since it's the same query that gets run for all clients.

## Context

New attributes have been added to request items that are required in the report.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
