### PR TITLE
Feature/ccm 8589 events alarming infra

### DIFF
--- a/infrastructure/terraform/components/acct/README.md
+++ b/infrastructure/terraform/components/acct/README.md
@@ -18,6 +18,7 @@
 | <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | A map of default tags to apply to all taggable resources within the component | `map(string)` | `{}` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The name of the tfscaffold environment | `string` | n/a | yes |
 | <a name="input_group"></a> [group](#input\_group) | The group variables are being inherited from (often synonmous with account short-name) | `string` | n/a | yes |
+| <a name="input_observability_account_id"></a> [observability\_account\_id](#input\_observability\_account\_id) | The Observability Account ID that needs access | `string` | n/a | yes |
 | <a name="input_project"></a> [project](#input\_project) | The name of the tfscaffold project | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The AWS Region | `string` | n/a | yes |
 ## Modules

--- a/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
+++ b/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_event_rule" "alert_forwarding" {
 
 resource "aws_cloudwatch_event_target" "alert_forwarding" {
   rule     = aws_cloudwatch_event_rule.alert_forwarding.name
-  arn      = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-obsconfig-alerts-bus"
+  arn      = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-acct-alerts-bus"
   role_arn = aws_iam_role.alert_forwarding.arn
 }
 

--- a/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
+++ b/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
@@ -1,0 +1,51 @@
+resource "aws_cloudwatch_event_rule" "alert_forwarding" {
+  name        = "${local.csi}-forward-cloudwatch-alarms"
+  description = "Forwards CloudWatch Alarm state changes to Account B"
+
+  event_pattern = jsonencode({
+    "source"      = ["aws.cloudwatch"],
+    "detail-type" = ["CloudWatch Alarm State Change"]
+  })
+}
+
+# Target: Send events to Account B's custom event bus
+resource "aws_cloudwatch_event_target" "alert_forwarding" {
+  rule     = aws_cloudwatch_event_rule.alert_forwarding.name
+  arn      = "arn:aws:events:eu-west-2:273354664196:event-bus/nhs-notify-main-obs-alerts-bus"
+  role_arn = aws_iam_role.alert_forwarding.arn
+}
+
+# IAM Role: Allow EventBridge to send events to Account B
+resource "aws_iam_role" "alert_forwarding" {
+  name = "${local.csi}-alert-forwarding"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Principal = {
+        Service = "events.amazonaws.com"
+      },
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+# IAM Policy: Allow publishing events to Account B's event bus
+resource "aws_iam_policy" "alert_forwarding" {
+  name = "${local.csi}-alert-forwarding"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect   = "Allow",
+      Action   = "events:PutEvents",
+      Resource = "arn:aws:events:eu-west-2:273354664196:event-bus/nhs-notify-main-obs-alerts-bus"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "alert_forwarding" {
+  role       = aws_iam_role.alert_forwarding.name
+  policy_arn = aws_iam_policy.alert_forwarding.arn
+}

--- a/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
+++ b/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
@@ -8,14 +8,12 @@ resource "aws_cloudwatch_event_rule" "alert_forwarding" {
   })
 }
 
-# Target: Send events to Account B's custom event bus
 resource "aws_cloudwatch_event_target" "alert_forwarding" {
   rule     = aws_cloudwatch_event_rule.alert_forwarding.name
   arn      = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-obs-alerts-bus"
   role_arn = aws_iam_role.alert_forwarding.arn
 }
 
-# IAM Role: Allow EventBridge to send events to Account B
 resource "aws_iam_role" "alert_forwarding" {
   name = "${local.csi}-alert-forwarding"
 
@@ -31,7 +29,6 @@ resource "aws_iam_role" "alert_forwarding" {
   })
 }
 
-# IAM Policy: Allow publishing events to Account B's event bus
 resource "aws_iam_policy" "alert_forwarding" {
   name = "${local.csi}-alert-forwarding"
 

--- a/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
+++ b/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_event_rule" "alert_forwarding" {
 
 resource "aws_cloudwatch_event_target" "alert_forwarding" {
   rule     = aws_cloudwatch_event_rule.alert_forwarding.name
-  arn      = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-obs-alerts-bus"
+  arn      = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-obsconfig-alerts-bus"
   role_arn = aws_iam_role.alert_forwarding.arn
 }
 
@@ -37,7 +37,7 @@ resource "aws_iam_policy" "alert_forwarding" {
     Statement = [{
       Effect   = "Allow",
       Action   = "events:PutEvents",
-      Resource = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-obs-alerts-bus"
+      Resource = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-obsconfig-alerts-bus"
     }]
   })
 }

--- a/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
+++ b/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_event_rule" "alert_forwarding" {
 # Target: Send events to Account B's custom event bus
 resource "aws_cloudwatch_event_target" "alert_forwarding" {
   rule     = aws_cloudwatch_event_rule.alert_forwarding.name
-  arn      = "arn:aws:events:eu-west-2:2${var.observability_account_id}:event-bus/nhs-notify-main-obs-alerts-bus"
+  arn      = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-obs-alerts-bus"
   role_arn = aws_iam_role.alert_forwarding.arn
 }
 

--- a/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
+++ b/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
@@ -37,7 +37,7 @@ resource "aws_iam_policy" "alert_forwarding" {
     Statement = [{
       Effect   = "Allow",
       Action   = "events:PutEvents",
-      Resource = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-obsconfig-alerts-bus"
+      Resource = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-acct-alerts-bus"
     }]
   })
 }

--- a/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
+++ b/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_event_rule" "alert_forwarding" {
   name        = "${local.csi}-forward-cloudwatch-alarms"
-  description = "Forwards CloudWatch Alarm state changes to Account B"
+  description = "Forwards CloudWatch Alarm state changes to Custom Event Bus in Observability Account"
 
   event_pattern = jsonencode({
     "source"      = ["aws.cloudwatch"],

--- a/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
+++ b/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_event_rule" "alert_forwarding" {
 # Target: Send events to Account B's custom event bus
 resource "aws_cloudwatch_event_target" "alert_forwarding" {
   rule     = aws_cloudwatch_event_rule.alert_forwarding.name
-  arn      = "arn:aws:events:eu-west-2:273354664196:event-bus/nhs-notify-main-obs-alerts-bus"
+  arn      = "arn:aws:events:eu-west-2:2${var.observability_account_id}:event-bus/nhs-notify-main-obs-alerts-bus"
   role_arn = aws_iam_role.alert_forwarding.arn
 }
 

--- a/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
+++ b/infrastructure/terraform/components/acct/cloudwatch_event_rule_alert_forwarding.tf
@@ -40,7 +40,7 @@ resource "aws_iam_policy" "alert_forwarding" {
     Statement = [{
       Effect   = "Allow",
       Action   = "events:PutEvents",
-      Resource = "arn:aws:events:eu-west-2:273354664196:event-bus/nhs-notify-main-obs-alerts-bus"
+      Resource = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-obs-alerts-bus"
     }]
   })
 }

--- a/infrastructure/terraform/components/acct/cloudwatch_event_rule_aws_backup_errors.tf
+++ b/infrastructure/terraform/components/acct/cloudwatch_event_rule_aws_backup_errors.tf
@@ -1,0 +1,51 @@
+resource "aws_cloudwatch_event_rule" "aws_backup_errors" {
+  name          = "${local.csi}-aws-backup-errors"
+  description = "Forwards AWS Backup state changes to Custom Event Bus in Observability Account"
+
+  event_pattern = jsonencode({
+    source      = ["aws.backup"],
+    "detail-type" = ["Backup Job State Change", "Restore Job State Change", "Copy Job State Change"],
+    detail = {
+      state = ["FAILED", "ABORTED"]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "aws_backup_errors" {
+  rule     = aws_cloudwatch_event_rule.aws_backup_errors.name
+  arn      = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-acct-alerts-bus"
+  role_arn = aws_iam_role.aws_backup_errors.arn
+}
+
+resource "aws_iam_role" "aws_backup_errors" {
+  name = "${local.csi}-aws-backup-errors"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Principal = {
+        Service = "events.amazonaws.com"
+      },
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_policy" "aws_backup_errors" {
+  name = "${local.csi}-aws-backup-errors"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect   = "Allow",
+      Action   = "events:PutEvents",
+      Resource = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-acct-alerts-bus"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "aws_backup_errors" {
+  role       = aws_iam_role.aws_backup_errors
+  policy_arn = aws_iam_policy.aws_backup_errors
+}

--- a/infrastructure/terraform/components/acct/cloudwatch_event_rule_aws_backup_errors.tf
+++ b/infrastructure/terraform/components/acct/cloudwatch_event_rule_aws_backup_errors.tf
@@ -46,6 +46,6 @@ resource "aws_iam_policy" "aws_backup_errors" {
 }
 
 resource "aws_iam_role_policy_attachment" "aws_backup_errors" {
-  role       = aws_iam_role.aws_backup_errors
-  policy_arn = aws_iam_policy.aws_backup_errors
+  role       = aws_iam_role.aws_backup_errors.name
+  policy_arn = aws_iam_policy.aws_backup_errors.arn
 }

--- a/infrastructure/terraform/components/acct/cloudwatch_event_rule_aws_backup_errors.tf
+++ b/infrastructure/terraform/components/acct/cloudwatch_event_rule_aws_backup_errors.tf
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_event_rule" "aws_backup_errors" {
 
 resource "aws_cloudwatch_event_target" "aws_backup_errors" {
   rule     = aws_cloudwatch_event_rule.aws_backup_errors.name
-  arn      = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-acct-alerts-bus"
+  arn      = local.event_bus_arn
   role_arn = aws_iam_role.aws_backup_errors.arn
 }
 
@@ -40,7 +40,7 @@ resource "aws_iam_policy" "aws_backup_errors" {
     Statement = [{
       Effect   = "Allow",
       Action   = "events:PutEvents",
-      Resource = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-acct-alerts-bus"
+      Resource = local.event_bus_arn
     }]
   })
 }

--- a/infrastructure/terraform/components/acct/cloudwatch_event_rule_cloudwatch_alarms.tf
+++ b/infrastructure/terraform/components/acct/cloudwatch_event_rule_cloudwatch_alarms.tf
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_event_rule" "cloudwatch_alarms" {
 
 resource "aws_cloudwatch_event_target" "cloudwatch_alarms" {
   rule     = aws_cloudwatch_event_rule.cloudwatch_alarms.name
-  arn      = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-acct-alerts-bus"
+  arn      = local.event_bus_arn
   role_arn = aws_iam_role.cloudwatch_alarms.arn
 }
 
@@ -37,7 +37,7 @@ resource "aws_iam_policy" "cloudwatch_alarms" {
     Statement = [{
       Effect   = "Allow",
       Action   = "events:PutEvents",
-      Resource = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-acct-alerts-bus"
+      Resource = local.event_bus_arn
     }]
   })
 }

--- a/infrastructure/terraform/components/acct/cloudwatch_event_rule_cloudwatch_alarms.tf
+++ b/infrastructure/terraform/components/acct/cloudwatch_event_rule_cloudwatch_alarms.tf
@@ -1,5 +1,5 @@
-resource "aws_cloudwatch_event_rule" "alert_forwarding" {
-  name        = "${local.csi}-forward-cloudwatch-alarms"
+resource "aws_cloudwatch_event_rule" "cloudwatch_alarms" {
+  name        = "${local.csi}-cloudwatch-alarm-fowarding"
   description = "Forwards CloudWatch Alarm state changes to Custom Event Bus in Observability Account"
 
   event_pattern = jsonencode({
@@ -8,14 +8,14 @@ resource "aws_cloudwatch_event_rule" "alert_forwarding" {
   })
 }
 
-resource "aws_cloudwatch_event_target" "alert_forwarding" {
-  rule     = aws_cloudwatch_event_rule.alert_forwarding.name
+resource "aws_cloudwatch_event_target" "cloudwatch_alarms" {
+  rule     = aws_cloudwatch_event_rule.cloudwatch_alarms.name
   arn      = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-acct-alerts-bus"
-  role_arn = aws_iam_role.alert_forwarding.arn
+  role_arn = aws_iam_role.cloudwatch_alarms.arn
 }
 
-resource "aws_iam_role" "alert_forwarding" {
-  name = "${local.csi}-alert-forwarding"
+resource "aws_iam_role" "cloudwatch_alarms" {
+  name = "${local.csi}-cloudwatch-alarms"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
@@ -29,8 +29,8 @@ resource "aws_iam_role" "alert_forwarding" {
   })
 }
 
-resource "aws_iam_policy" "alert_forwarding" {
-  name = "${local.csi}-alert-forwarding"
+resource "aws_iam_policy" "cloudwatch_alarms" {
+  name = "${local.csi}-cloudwatch-alarms"
 
   policy = jsonencode({
     Version = "2012-10-17",
@@ -42,7 +42,7 @@ resource "aws_iam_policy" "alert_forwarding" {
   })
 }
 
-resource "aws_iam_role_policy_attachment" "alert_forwarding" {
-  role       = aws_iam_role.alert_forwarding.name
-  policy_arn = aws_iam_policy.alert_forwarding.arn
+resource "aws_iam_role_policy_attachment" "cloudwatch_alarms" {
+  role       = aws_iam_role.cloudwatch_alarms.name
+  policy_arn = aws_iam_policy.cloudwatch_alarms.arn
 }

--- a/infrastructure/terraform/components/acct/locals.tf
+++ b/infrastructure/terraform/components/acct/locals.tf
@@ -6,4 +6,6 @@ locals {
       "arn:aws:glue:${var.region}:${account_id}:catalog",
     ]
   ]) : []
+
+  event_bus_arn = "arn:aws:events:eu-west-2:${var.observability_account_id}:event-bus/nhs-notify-main-acct-alerts-bus"
 }

--- a/infrastructure/terraform/components/acct/variables.tf
+++ b/infrastructure/terraform/components/acct/variables.tf
@@ -56,3 +56,8 @@ variable "core_account_ids" {
   description = "List of core account IDs"
   default     = []
 }
+
+variable "observability_account_id" {
+  type        = string
+  description = "The Observability Account ID that needs access"
+}

--- a/infrastructure/terraform/components/reporting/iam_role_grafana_access.tf
+++ b/infrastructure/terraform/components/reporting/iam_role_grafana_access.tf
@@ -19,7 +19,7 @@ data "aws_iam_policy_document" "observability_grafana_role_assume_role_policy" {
       variable = "aws:PrincipalArn"
 
       values = [
-        "arn:aws:iam::${var.observability_account_id}:role/*grafana-workspace-role"
+        "arn:aws:iam::${var.observability_account_id}:role/*obs-workspace-role"
       ]
     }
   }

--- a/infrastructure/terraform/components/reporting/iam_role_grafana_access.tf
+++ b/infrastructure/terraform/components/reporting/iam_role_grafana_access.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "grafana_access" {
-  name               = replace("${local.csi}-grafana-cross-access-role", "-${var.component}", "")
+  name               = replace("${local.csi}-obs-cross-access-role", "-${var.component}", "")
   description        = "IAM role for Grafana workspace to access this account"
   assume_role_policy = data.aws_iam_policy_document.observability_grafana_role_assume_role_policy.json
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds an alert rule to the default event bus to pass Cloudwatch Alarm state changes to the Observability account's custom event bus.

## Context

Provides a routing of alarms from bounded context to central Obs account.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
