### PR TITLE
CCM-9148 Add watchdog query for the stuck items observed in the above incident

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Watchdog queries and corresponding metrics and alarms are currently setup for th
 | Request item plans unexpectedly incomplete | overdue_request_item_plans | OverdueRequestItemPlansCount | Sum across all clients > 0 | overdue-request-item-plans |
 | Request items incomplete after 2 weeks     | overdue_request_items      | OverdueRequestItemsCount     | Sum across all clients > 0 | overdue-request-items      |
 | Requests incomplete after 2 weeks          | overdue_requests           | OverdueRequestsCount         | Sum across all clients > 0 | overdue-requests           |
+| Request items stuck before being sent      | stuck_request_items        | StuckRequestItemsCount       | Sum across all clients > 0 | stuck-request-items        |
 
 ## Contacts
 

--- a/infrastructure/terraform/components/reporting/athena_named_query_stuck_request_items.tf
+++ b/infrastructure/terraform/components/reporting/athena_named_query_stuck_request_items.tf
@@ -1,0 +1,11 @@
+resource "aws_athena_named_query" "stuck_request_items" {
+  name        = "stuck_request_items"
+  description = "Query to determine any request items unexpectedly stuck in an ENRICHED or PENDING_ENRICHMENT state"
+  workgroup   = aws_athena_workgroup.user.id
+  database    = aws_glue_catalog_database.reporting.name
+  query       = file("${path.module}/scripts/sql/watchdog/stuck_request_items.sql")
+
+  depends_on = [
+    null_resource.request_item_status_table
+  ]
+}

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_overdue_request_item_plans.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_overdue_request_item_plans.tf
@@ -3,7 +3,7 @@ resource "aws_cloudwatch_metric_alarm" "overdue_request_item_plans" {
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
   threshold           = 1
-  alarm_description   = "This metric monitors unexpected/overdue request item plans"
+  alarm_description   = "Request item plans that did not reach a terminal state within an expected time window"
 
   metric_query {
     id          = "max_overdue_request_item_plans_count"

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_overdue_request_items.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_overdue_request_items.tf
@@ -3,7 +3,7 @@ resource "aws_cloudwatch_metric_alarm" "overdue_request_items" {
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
   threshold           = 1
-  alarm_description   = "This metric monitors unexpected/overdue request items"
+  alarm_description   = "Request items that did not reach a terminal state within an expected time window"
 
   metric_query {
     id          = "max_overdue_request_items_count"

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_overdue_requests.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_overdue_requests.tf
@@ -3,7 +3,7 @@ resource "aws_cloudwatch_metric_alarm" "overdue_requests" {
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
   threshold           = 1
-  alarm_description   = "This metric monitors unexpected/overdue requests"
+  alarm_description   = "Requests that did not reach a terminal state within an expected time window"
 
   metric_query {
     id          = "max_overdue_requests_count"

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_stuck_request_items.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_stuck_request_items.tf
@@ -1,0 +1,14 @@
+resource "aws_cloudwatch_metric_alarm" "stuck_request_items" {
+  alarm_name          = "${local.csi}-stuck-request-items"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  threshold           = 1
+  alarm_description   = "Request items stuck in an ENRICHED or PENDING_ENRICHMENT state for longer than an expected time window"
+
+  metric_query {
+    id          = "max_stuck_request_items_count"
+    expression  = "SELECT MAX(StuckRequestItemsCount) FROM \"Notify/Watchdog\" WHERE environment='${var.environment}'"
+    return_data = "true"
+    period      = 3600
+  }
+}

--- a/infrastructure/terraform/components/reporting/scripts/sql/watchdog/stuck_request_items.sql
+++ b/infrastructure/terraform/components/reporting/scripts/sql/watchdog/stuck_request_items.sql
@@ -1,0 +1,13 @@
+SELECT
+  clientid,
+  COALESCE(campaignid, 'N/A'),
+  SUM(
+    CASE
+      WHEN status='ENRICHED' AND createdtime < DATE_ADD('day', -6, CURRENT_DATE) THEN 1
+      WHEN status='PENDING_ENRICHMENT' AND createdtime < DATE_ADD('day', -2, CURRENT_DATE) THEN 1
+      ELSE 0
+    END
+  )
+FROM request_item_status
+WHERE createdtime >= DATE_ADD('day', -90, CURRENT_DATE)
+GROUP BY clientid, campaignid

--- a/infrastructure/terraform/components/reporting/sfn_state_machine_watchdog.tf
+++ b/infrastructure/terraform/components/reporting/sfn_state_machine_watchdog.tf
@@ -15,6 +15,10 @@ resource "aws_sfn_state_machine" "watchdog" {
       {
         metric_name = "OverdueRequestsCount",
         query_id    = aws_athena_named_query.overdue_requests.id
+      },
+      {
+        metric_name = "StuckRequestItemsCount",
+        query_id    = aws_athena_named_query.stuck_request_items.id
       }
     ]
     environment = var.environment


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Adds a new watchdog query to identify items that are stuck in an ENRICHED or PENDING_ENRICHMENT state

## Context
Existing watchdog queries look for items that have not reached a terminal state. Because cascading multi-channel routing configurations can reach a long time to reach terminal state these are not as responsive as they could be to problems in enrichment or routing.

This change adds a new watchdog query for items that are stuck earlier in their processing that can be more responsive.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
