### PR TITLE
CCM-6801 Allow 2 minute tolerance on unsociable hours

### DIFF
--- a/infrastructure/terraform/components/reporting/scripts/sql/views/latency_percentiles.sql
+++ b/infrastructure/terraform/components/reporting/scripts/sql/views/latency_percentiles.sql
@@ -48,7 +48,9 @@ WHERE starttime IS NOT NULL
 AND endtime IS NOT NULL
 AND starttime > DATE('2000-01-01')
 AND DAY_OF_WEEK(starttime) <= 5
-AND HOUR(AT_TIMEZONE(starttime, 'Europe/London')) < 18
-AND HOUR(AT_TIMEZONE(starttime, 'Europe/London')) >= 8
+AND HOUR(AT_TIMEZONE(DATE_ADD('minute', 2, starttime), 'Europe/London')) < 18
+AND HOUR(AT_TIMEZONE(DATE_ADD('minute', -2, starttime), 'Europe/London')) < 18
+AND HOUR(AT_TIMEZONE(DATE_ADD('minute', 2, starttime), 'Europe/London')) >= 8
+AND HOUR(AT_TIMEZONE(DATE_ADD('minute', -2, starttime), 'Europe/London')) >= 8
 GROUP BY clientid, campaignid, communicationtype, percentile
 ORDER BY clientid, campaignid, communicationtype, percentile


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Changes the latency view so that there is a 2-minute tolerance on messages approaching the unsociable hours window.

Previously we were seeing messages that cascaded immediately before the window started but not being picked up immediately as showing as high latencies.

## Context

Increases the accuracy of the latency dashboard

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
