### PR TITLE
CCM-9740: Treating missing data as not breaching to stop false alarms

### DIFF
--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_completed_batch_report_executions_aborted.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_completed_batch_report_executions_aborted.tf
@@ -9,6 +9,7 @@ resource "aws_cloudwatch_metric_alarm" "completed_batch_report_executions_aborte
   threshold                 = 1
   alarm_description         = "This metric monitors failed step function executions"
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
 
   dimensions = {
     StateMachineArn = aws_sfn_state_machine.completed_batch_report.arn

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_completed_batch_report_executions_failed.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_completed_batch_report_executions_failed.tf
@@ -9,6 +9,7 @@ resource "aws_cloudwatch_metric_alarm" "completed_batch_report_executions_failed
   threshold                 = 1
   alarm_description         = "This metric monitors failed step function executions"
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
 
   dimensions = {
     StateMachineArn = aws_sfn_state_machine.completed_batch_report.arn

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_completed_batch_report_executions_timedout.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_completed_batch_report_executions_timedout.tf
@@ -9,6 +9,7 @@ resource "aws_cloudwatch_metric_alarm" "completed_batch_report_executions_timedo
   threshold                 = 1
   alarm_description         = "This metric monitors step function execution timeouts"
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
 
   dimensions = {
     StateMachineArn = aws_sfn_state_machine.completed_batch_report.arn

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_completed_comms_report_executions_aborted.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_completed_comms_report_executions_aborted.tf
@@ -8,6 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "completed_comms_report_executions_aborte
   statistic           = "Sum"
   threshold           = 1
   alarm_description   = "This metric monitors failed step function executions"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     StateMachineArn = aws_sfn_state_machine.completed_comms_report.arn

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_completed_comms_report_executions_failed.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_completed_comms_report_executions_failed.tf
@@ -8,6 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "completed_comms_report_executions_failed
   statistic           = "Sum"
   threshold           = 1
   alarm_description   = "This metric monitors failed step function executions"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     StateMachineArn = aws_sfn_state_machine.completed_comms_report.arn

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_completed_comms_report_executions_timedout.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_completed_comms_report_executions_timedout.tf
@@ -8,6 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "completed_comms_report_executions_timedo
   statistic           = "Sum"
   threshold           = 1
   alarm_description   = "This metric monitors step function execution timeouts"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     StateMachineArn = aws_sfn_state_machine.completed_comms_report.arn

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_housekeeping_executions_aborted.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_housekeeping_executions_aborted.tf
@@ -8,6 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "housekeeping_executions_aborted" {
   statistic           = "Sum"
   threshold           = 1
   alarm_description   = "This metric monitors failed step function executions"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     StateMachineArn = aws_sfn_state_machine.housekeeping.arn

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_housekeeping_executions_failed.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_housekeeping_executions_failed.tf
@@ -8,6 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "housekeeping_executions_failed" {
   statistic           = "Sum"
   threshold           = 1
   alarm_description   = "This metric monitors failed step function executions"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     StateMachineArn = aws_sfn_state_machine.housekeeping.arn

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_housekeeping_executions_timedout.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_housekeeping_executions_timedout.tf
@@ -8,6 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "housekeeping_executions_timedout" {
   statistic           = "Sum"
   threshold           = 1
   alarm_description   = "This metric monitors step function execution timeouts"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     StateMachineArn = aws_sfn_state_machine.housekeeping.arn

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_ingestion_executions_aborted.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_ingestion_executions_aborted.tf
@@ -8,6 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "ingestion_executions_aborted" {
   statistic           = "Sum"
   threshold           = 1
   alarm_description   = "This metric monitors failed step function executions"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     StateMachineArn = aws_sfn_state_machine.ingestion.arn

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_ingestion_executions_failed.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_ingestion_executions_failed.tf
@@ -8,6 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "ingestion_executions_failed" {
   statistic           = "Sum"
   threshold           = 1
   alarm_description   = "This metric monitors failed step function executions"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     StateMachineArn = aws_sfn_state_machine.ingestion.arn

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_ingestion_executions_timedout.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_ingestion_executions_timedout.tf
@@ -8,6 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "ingestion_executions_timedout" {
   statistic           = "Sum"
   threshold           = 1
   alarm_description   = "This metric monitors step function execution timeouts"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     StateMachineArn = aws_sfn_state_machine.ingestion.arn

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_overdue_request_item_plans.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_overdue_request_item_plans.tf
@@ -4,6 +4,7 @@ resource "aws_cloudwatch_metric_alarm" "overdue_request_item_plans" {
   evaluation_periods  = 1
   threshold           = 1
   alarm_description   = "Request item plans that did not reach a terminal state within an expected time window"
+  treat_missing_data  = "notBreaching"
 
   metric_query {
     id          = "max_overdue_request_item_plans_count"

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_overdue_request_items.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_overdue_request_items.tf
@@ -4,6 +4,7 @@ resource "aws_cloudwatch_metric_alarm" "overdue_request_items" {
   evaluation_periods  = 1
   threshold           = 1
   alarm_description   = "Request items that did not reach a terminal state within an expected time window"
+  treat_missing_data  = "notBreaching"
 
   metric_query {
     id          = "max_overdue_request_items_count"

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_overdue_requests.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_overdue_requests.tf
@@ -4,6 +4,7 @@ resource "aws_cloudwatch_metric_alarm" "overdue_requests" {
   evaluation_periods  = 1
   threshold           = 1
   alarm_description   = "Requests that did not reach a terminal state within an expected time window"
+  treat_missing_data  = "notBreaching"
 
   metric_query {
     id          = "max_overdue_requests_count"

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_s3_backup_failures.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_s3_backup_failures.tf
@@ -10,6 +10,7 @@ resource "aws_cloudwatch_metric_alarm" "s3_backup_failures" {
   statistic           = "Sum"
   threshold           = 1
   alarm_description   = "This metric monitors AWS Backup Failures"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     BackupVaultName = aws_backup_vault.s3_backup[0].name

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_stuck_request_items.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_stuck_request_items.tf
@@ -4,6 +4,7 @@ resource "aws_cloudwatch_metric_alarm" "stuck_request_items" {
   evaluation_periods  = 1
   threshold           = 1
   alarm_description   = "Request items stuck in an ENRICHED or PENDING_ENRICHMENT state for longer than an expected time window"
+  treat_missing_data  = "notBreaching"
 
   metric_query {
     id          = "max_stuck_request_items_count"

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_watchdog_executions_aborted.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_watchdog_executions_aborted.tf
@@ -8,6 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "watchdog_executions_aborted" {
   statistic           = "Sum"
   threshold           = 1
   alarm_description   = "This metric monitors failed step function executions"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     StateMachineArn = aws_sfn_state_machine.watchdog.arn

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_watchdog_executions_failed.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_watchdog_executions_failed.tf
@@ -8,6 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "watchdog_executions_failed" {
   statistic           = "Sum"
   threshold           = 1
   alarm_description   = "This metric monitors failed step function executions"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     StateMachineArn = aws_sfn_state_machine.watchdog.arn

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_watchdog_executions_timedout.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_watchdog_executions_timedout.tf
@@ -8,6 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "watchdog_executions_timedout" {
   statistic           = "Sum"
   threshold           = 1
   alarm_description   = "This metric monitors step function execution timeouts"
+  treat_missing_data  = "notBreaching"
 
   dimensions = {
     StateMachineArn = aws_sfn_state_machine.watchdog.arn


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Setting alarms to treat missing data as "not breaching"

## Context

We have alarms set currently using terraform, by default, cloudwatch alarms created with terraform treat missing data as "missing", which means when the metric/query that the alarm is set against, if there is not data generated, it would treat that as a problem and trigger alarms, this leads to a lot of times us getting alarm notifications when there might not be a problem. Generally, it is best practice to set them to "not breaching", so that it only evaluates about a problem when there is cause.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
