### PR TITLE
CCM-10045: move latest client name ingestion to phase 1

### DIFF
--- a/infrastructure/terraform/components/reporting/sfn_state_machine_ingestion.tf
+++ b/infrastructure/terraform/components/reporting/sfn_state_machine_ingestion.tf
@@ -4,7 +4,8 @@ resource "aws_sfn_state_machine" "ingestion" {
 
   definition = templatefile("${path.module}/templates/ingestion.json.tmpl", {
     query_ids_1 = [
-      "${aws_athena_named_query.request_item_plan_status.id}"
+      "${aws_athena_named_query.request_item_plan_status.id}",
+      "${aws_athena_named_query.client_latest_name.id}"
     ]
     hash_query_ids_1 = [
       "${aws_athena_named_query.request_item_status.id}"
@@ -13,8 +14,7 @@ resource "aws_sfn_state_machine" "ingestion" {
       "${aws_athena_named_query.request_item_plan_completed_summary.id}",
       "${aws_athena_named_query.request_item_plan_completed_summary_batch.id}",
       "${aws_athena_named_query.request_item_status_summary.id}",
-      "${aws_athena_named_query.request_item_status_summary_batch.id}",
-      "${aws_athena_named_query.client_latest_name.id}"
+      "${aws_athena_named_query.request_item_status_summary_batch.id}"
     ]
     hash_query_ids_2 = []
     environment      = "${local.csi}"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Move the client_latest_name ingestion query to be part of the phase 1 ingestion

## Context

Phase 1 queries are expected to extract data for core and resolve first, such that any downstream dependencies will have core data available

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
