### PR TITLE
CCM-10807 Fix issue with completed comms and batch reports

### DIFF
--- a/infrastructure/terraform/components/reporting/athena_workgroup_core.tf
+++ b/infrastructure/terraform/components/reporting/athena_workgroup_core.tf
@@ -8,7 +8,7 @@ resource "aws_athena_workgroup" "core" {
   force_destroy = true
 
   configuration {
-    enforce_workgroup_configuration = true
+    enforce_workgroup_configuration = false
 
     result_configuration {
       expected_bucket_owner = var.core_account_id

--- a/infrastructure/terraform/components/reporting/athena_workgroup_core.tf
+++ b/infrastructure/terraform/components/reporting/athena_workgroup_core.tf
@@ -8,6 +8,8 @@ resource "aws_athena_workgroup" "core" {
   force_destroy = true
 
   configuration {
+    # The Completed Comms and Completed Batch reports, both rely on being able to specify the 'output_location'.
+    # 'enforce_workgroup_configuration = true' silently ignores the output_location specified by the reports and saves everything to the root of the bucket. 
     enforce_workgroup_configuration = false
 
     result_configuration {

--- a/infrastructure/terraform/components/reporting/athena_workgroup_core.tf
+++ b/infrastructure/terraform/components/reporting/athena_workgroup_core.tf
@@ -8,8 +8,8 @@ resource "aws_athena_workgroup" "core" {
   force_destroy = true
 
   configuration {
-    # The Completed Comms and Completed Batch reports, both rely on being able to specify the 'output_location'.
-    # 'enforce_workgroup_configuration = true' silently ignores the output_location specified by the reports and saves everything to the root of the bucket. 
+    # The Completed Comms and Completed Batch reports both rely on being able to specify the 'output_location'.
+    # 'enforce_workgroup_configuration = true' silently ignores the output_location specified by the reports and saves everything to the root of the bucket.
     enforce_workgroup_configuration = false
 
     result_configuration {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Change `enforce_workgroup_configuration` from true to false for the core Athena workgroup.

## Context
The Completed Comms and Completed Batch reports run queries within the core workgroup. As part of the report process, the Athena query results should be saved to S3 under client and date specific subfolders. As the workgroup has been configured to not allow this, all the reports are being saved to the root of the bucket.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
