### PR TITLE
CCM-12210: Proco week-start bug

### DIFF
--- a/infrastructure/terraform/components/reporting/scripts/sql/views/letters_invoice_units_monthly.sql
+++ b/infrastructure/terraform/components/reporting/scripts/sql/views/letters_invoice_units_monthly.sql
@@ -11,6 +11,8 @@ FROM (
                     WHEN DAY_OF_WEEK(sendtime)=7 THEN DATE_ADD('day', 3, sendtime)
                     ELSE DATE_ADD('day', 2, sendtime)
                 END
+            WHEN supplier='PRECISIONPROCO' THEN
+                DATE_ADD('day', 2, sendtime)
             ELSE sendtime
         END AS invoicetime
     FROM request_item_plan_status

--- a/infrastructure/terraform/components/reporting/scripts/sql/views/letters_invoice_units_weekly.sql
+++ b/infrastructure/terraform/components/reporting/scripts/sql/views/letters_invoice_units_weekly.sql
@@ -11,6 +11,8 @@ FROM (
                     WHEN DAY_OF_WEEK(sendtime)=7 THEN DATE_ADD('day', 3, sendtime)
                     ELSE DATE_ADD('day', 2, sendtime)
                 END
+            WHEN supplier='PRECISIONPROCO' THEN
+                DATE_ADD('day', 2, sendtime)
             ELSE sendtime
         END AS invoicetime
     FROM request_item_plan_status


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Change the week-end logic so that Proco invoices reconcile correctly for messages sent on a Saturday and Sunday.

## Context

Currently the invoice reconciliation reports messages frm Saturday and Sunday in the wrong invoice week.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
