### PR TITLE
CCM-12405 Remove transaction_history_old references

### DIFF
--- a/infrastructure/terraform/components/reporting/scripts/sql/README.md
+++ b/infrastructure/terraform/components/reporting/scripts/sql/README.md
@@ -333,6 +333,5 @@ A data migration query is usually very similar to the corresponding ingestion qu
 Key differences include:
 
 - The sliding time window is omitted so that all available rows in the source table are available
-- The migration queries use a `UNION ALL` operator to pull from both `transaction_history_old` and `transaction_history` tables
-- Historic indiosyncrasies are accounted for (such as the change from second-precision to millisecond-precision timestamps between `transaction_history_old` and `transaction_history` tables)
+- Historic indiosyncrasies are accounted for (such as some legacy timestamps that were not ISO8601 compliant)
 - Migration queries may include specific amendments to rectify historic data quality issues

--- a/infrastructure/terraform/components/reporting/scripts/sql/migration/request_item_plan_status.sql
+++ b/infrastructure/terraform/components/reporting/scripts/sql/migration/request_item_plan_status.sql
@@ -11,28 +11,6 @@ USING (
     FROM (
       SELECT
         clientid,
-        NULL as campaignid,
-        sendinggroupid,
-        sendinggroupidversion,
-        requestitemrefid,
-        requestitemid,
-        requestrefid,
-        requestid,
-        requestitemplanid,
-        communicationtype,
-        supplier,
-        from_iso8601_timestamp(createddate) AS createdtime,
-        from_iso8601_timestamp(completeddate) AS completedtime,
-        status,
-        failedreason,
-        NULL as contactdetailsource,
-        NULL as channeltype,
-        CAST("$classification".timestamp AS BIGINT) * 1000 AS timestamp --transaction_history_old has second granularity timestamps
-      FROM transaction_history_old
-      WHERE (sk LIKE 'REQUEST_ITEM_PLAN#%')
-      UNION ALL
-      SELECT
-        clientid,
         campaignid,
         sendinggroupid,
         sendinggroupidversion,

--- a/infrastructure/terraform/components/reporting/scripts/sql/migration/request_item_status.sql
+++ b/infrastructure/terraform/components/reporting/scripts/sql/migration/request_item_status.sql
@@ -11,27 +11,6 @@ USING (
     FROM (
       SELECT
         clientid,
-        NULL AS campaignid,
-        sendinggroupid,
-        sendinggroupidversion,
-        requestitemrefid,
-        requestitemid,
-        requestrefid,
-        requestid,
-        to_base64(sha256(cast((? || '.' || nhsnumber) AS varbinary))) AS nhsnumberhash,
-        from_iso8601_timestamp(createddate) AS createdtime,
-        from_iso8601_timestamp(completeddate) AS completedtime,
-        completedcommunicationtypes,
-        failedcommunicationtypes,
-        status,
-        failedreason,
-        NULL AS patientodscode,
-        CAST("$classification".timestamp AS BIGINT) * 1000 AS timestamp --transaction_history_old has second granularity timestamps
-      FROM transaction_history_old
-      WHERE (sk LIKE 'REQUEST_ITEM#%')
-      UNION ALL
-      SELECT
-        clientid,
         campaignid,
         sendinggroupid,
         sendinggroupidversion,


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Removes all references to transaction_history_old 

## Context

All data has now expired from the S3 bucket that was backing the legacy transaction_history_old Glue table.

There is no point querying this table, and removing references allows the underlying table definition to be removed in core.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
