### PR TITLE
Feature/ccm 12280 cost spike indicator athena workgroup

### DIFF
--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_athena_workgroup_processed_bytes_core.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_athena_workgroup_processed_bytes_core.tf
@@ -1,0 +1,16 @@
+resource "aws_cloudwatch_metric_alarm" "athena_workgroup_processed_bytes_core" {
+  alarm_name          = "${local.csi}-athena-workgroup-processed-bytes-core"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ProcessedBytes"
+  namespace           = "AWS/Athena"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 1000000000
+  alarm_description   = "Alarm for spikes in Athena Workgroup ProcessedBytes."
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    WorkGroup = aws_athena_workgroup.core.name
+  }
+}

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_athena_workgroup_processed_bytes_core.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_athena_workgroup_processed_bytes_core.tf
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_metric_alarm" "athena_workgroup_processed_bytes_core" {
   period              = 300
   statistic           = "Sum"
   threshold           = 1000000000
-  alarm_description   = "Alarm for spikes in Athena Workgroup ProcessedBytes."
+  alarm_description   = "Alarm for spikes in Athena Workgroup ProcessedBytes (core)."
   treat_missing_data  = "notBreaching"
 
   dimensions = {

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_athena_workgroup_processed_bytes_housekeeping.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_athena_workgroup_processed_bytes_housekeeping.tf
@@ -1,0 +1,15 @@
+resource "aws_cloudwatch_metric_alarm" "athena_workgroup_processed_bytes_housekeeping" {
+  alarm_name          = "${local.csi}-athena-workgroup-processed-bytes-housekeeping"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ProcessedBytes"
+  namespace           = "AWS/Athena"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 1000000000
+  alarm_description   = "Alarm for spikes in Athena Workgroup ProcessedBytes (housekeeping)."
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    WorkGroup = aws_athena_workgroup.housekeeping.name
+  }
+}

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_athena_workgroup_processed_bytes_ingestion.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_athena_workgroup_processed_bytes_ingestion.tf
@@ -1,0 +1,15 @@
+resource "aws_cloudwatch_metric_alarm" "athena_workgroup_processed_bytes_ingestion" {
+  alarm_name          = "${local.csi}-athena-workgroup-processed-bytes-ingestion"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ProcessedBytes"
+  namespace           = "AWS/Athena"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 1000000000
+  alarm_description   = "Alarm for spikes in Athena Workgroup ProcessedBytes (ingestion)."
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    WorkGroup = aws_athena_workgroup.ingestion.name
+  }
+}

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_athena_workgroup_processed_bytes_setup.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_athena_workgroup_processed_bytes_setup.tf
@@ -1,0 +1,15 @@
+resource "aws_cloudwatch_metric_alarm" "athena_workgroup_processed_bytes_setup" {
+  alarm_name          = "${local.csi}-athena-workgroup-processed-bytes-setup"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ProcessedBytes"
+  namespace           = "AWS/Athena"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 1000000000
+  alarm_description   = "Alarm for spikes in Athena Workgroup ProcessedBytes (setup)."
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    WorkGroup = aws_athena_workgroup.setup.name
+  }
+}

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_athena_workgroup_processed_bytes_user.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_athena_workgroup_processed_bytes_user.tf
@@ -1,0 +1,15 @@
+resource "aws_cloudwatch_metric_alarm" "athena_workgroup_processed_bytes_user" {
+  alarm_name          = "${local.csi}-athena-workgroup-processed-bytes-user"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ProcessedBytes"
+  namespace           = "AWS/Athena"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 1000000000
+  alarm_description   = "Alarm for spikes in Athena Workgroup ProcessedBytes (user)."
+  treat_missing_data  = "notBreaching"
+  dimensions = {
+    WorkGroup = aws_athena_workgroup.user.name
+  }
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds metric alarms for Processed Bytes for each Athena Workgroup.

## Context

Should catch large spikes in usage as seen earlier this year.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
