### PR TITLE
CCM-12593: Reduce latency alarm sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Watchdog queries and corresponding metrics and alarms are currently setup for th
 | Request items incomplete after 2 weeks      | overdue_request_items      | OverdueRequestItemsCount     | Sum across all clients > 0 | overdue-request-items      |
 | Requests incomplete after 2 weeks           | overdue_requests           | OverdueRequestsCount         | Sum across all clients > 0 | overdue-requests           |
 | Request items stuck before being sent       | stuck_request_items        | StuckRequestItemsCount       | Sum across all clients > 0 | stuck-request-items        |
-| Degraded latency compared to historic trend | degraded_latency           | DegradedLatenciesCount       | Sum across all clients > 0 | degraded-latency           |
+| Degraded latency compared to historic trend | degraded_latency           | DegradedLatenciesCount       | Count of clients > 1       | degraded-latency           |
 
 ## Contacts
 

--- a/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_degraded_latency.tf
+++ b/infrastructure/terraform/components/reporting/cloudwatch_metric_alarm_degraded_latency.tf
@@ -1,15 +1,25 @@
+locals {
+  alarm_period = 3600
+}
+
 resource "aws_cloudwatch_metric_alarm" "degraded_latency" {
   alarm_name          = "${local.csi}-degraded-latency"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = 1
-  threshold           = 1
-  alarm_description   = "Today's latencies are significantly higher than historic trends"
+  threshold           = 2
+  alarm_description   = "Triggers when multiple degraded-latency metrics are nonzero"
   treat_missing_data  = "notBreaching"
 
   metric_query {
-    id          = "max_degraded_latency_count"
-    expression  = "SELECT MAX(DegradedLatenciesCount) FROM \"Notify/Watchdog\" WHERE environment='${var.environment}'"
-    return_data = "true"
-    period      = 3600
+    id          = "count_degraded"
+    expression  = <<-EOT
+      SELECT COUNT_IF(DegradedLatenciesCount > 0)
+      FROM "Notify/Watchdog"
+      WHERE environment='${var.environment}'
+      GROUP BY PERIOD(${local.alarm_period} SECONDS)
+      FILL(0)
+    EOT
+    return_data = true
+    period      = local.alarm_period
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Only trigger alarm if more than one client experiences high latency simultaneously

## Context

At the moment the latency alarm is overly sensitive, and will trigger if a given client is just processing larger batches than usual.

This changes the threshold to look for noisy-neighbour syndrome, with at least two clients experiencing the higher latencies concurrently. A single client being slower than usual will no longer trigger the alarm,

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
